### PR TITLE
TargetJsonLayoutCard - Add Target ContextProperties as facts

### DIFF
--- a/NLog.Targets.Teams.Test.App/nlog.config
+++ b/NLog.Targets.Teams.Test.App/nlog.config
@@ -11,19 +11,19 @@
   
   <!-- the targets to write to -->
   <targets>
-    <!-- write logs to file -->    
+    <!-- write logs to file -->
     <target xsi:type="Console" name="console"
             layout="${date}|${level:uppercase=true}|${message} ${exception}|${logger}|${all-event-properties}" />
     <target xsi:type="Debugger" name="debugger"
             layout="${date}|${level:uppercase=true}|${message} ${exception}|${logger}|${all-event-properties}" />
-    <!-- Default message Card Configuration -->    
-    <target xsi:type="MsTeams" name="fatalLog" 
-          Url="XXX PUT YOUR URL IN HERE XXX"          
+    <!-- Default message Card Configuration -->
+    <target xsi:type="MsTeams" name="fatalLog"
+          Url="XXX PUT YOUR URL IN HERE XXX"
           ApplicationName="${var:appName}"
-          Environment="Demonstration"
-    />    
-    <!-- Custom message Card Configuration -->
-    <!-- uncomment this for a demo
+          Environment="Demonstration">
+      />
+      <!-- Custom message Card Configuration -->
+      <!-- uncomment this for a demo
     <target xsi:type="MsTeams" name="fatalLog"
           Url="XXX PUT YOUR URL IN HERE XXX"
           ApplicationName="Demo App"
@@ -31,8 +31,10 @@
           CardImpl="NLog.Targets.Teams.Test.App.CustomMessageCard"
           CardAssembly="NLog.Targets.Teams.Test.App"
     -->
-    />
-    
+      <contextproperty name="level" layout="${level}" />
+      <contextproperty name="message" layout="${message}" />
+    </target>
+
   </targets>
 
   <!-- rules to map from logger name to target -->

--- a/NLog.Targets.Teams/TargetJsonLayoutCard.cs
+++ b/NLog.Targets.Teams/TargetJsonLayoutCard.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using NLog.Layouts;
+
+namespace NLog.Targets.Teams
+{
+    internal class TargetJsonLayoutCard : IMessageCard
+    {
+        private readonly MsTeams.MsTeamsTarget _target;
+
+        public TargetJsonLayoutCard(MsTeams.MsTeamsTarget target)
+        {
+            _target = target;
+
+            var messageCardLayout = new JsonLayout() { EscapeForwardSlash = false };
+            messageCardLayout.Attributes.Add(new JsonAttribute("@type", "MessageCard"));
+            messageCardLayout.Attributes.Add(new JsonAttribute("context", "http://schema.org/extensions"));
+            messageCardLayout.Attributes.Add(new JsonAttribute("themeColor", "${when:when=level==LogLevel.Trace:inner=ffffff}"));
+            messageCardLayout.Attributes.Add(new JsonAttribute("themeColor", "${when:when=level==LogLevel.Debug:inner=00ff00}"));
+            messageCardLayout.Attributes.Add(new JsonAttribute("themeColor", "${when:when=level==LogLevel.Info:inner=0094FF}"));
+            messageCardLayout.Attributes.Add(new JsonAttribute("themeColor", "${when:when=level==LogLevel.Warn:inner=FFE97F}"));
+            messageCardLayout.Attributes.Add(new JsonAttribute("themeColor", "${when:when=level==LogLevel.Error:inner=ff0000}"));
+            messageCardLayout.Attributes.Add(new JsonAttribute("themeColor", "${when:when=level==LogLevel.Fatal:inner=000000}"));
+            messageCardLayout.Attributes.Add(new JsonAttribute("themeColor", "${when:when=level==LogLevel.Off:inner=ffffff}"));
+            messageCardLayout.Attributes.Add(new JsonAttribute("title", target.ApplicationName));
+            messageCardLayout.Attributes.Add(new JsonAttribute("text", target.Environment));
+
+            // Using CompoundLayout for building a JSON-Array
+            var facts = new CompoundLayout();
+            if (target.ContextProperties.Count > 0)
+            {
+                facts.Layouts.Add(new SimpleLayout("[ "));
+                for (int i = 0; i < target.ContextProperties.Count; ++i)
+                {
+                    if (i != 0)
+                        facts.Layouts.Add(new SimpleLayout(", "));
+
+                    var fact = target.ContextProperties[i];
+                    facts.Layouts.Add(new JsonLayout()
+                    {
+                        Attributes = {
+                            new JsonAttribute("name", fact.Name) { EscapeForwardSlash = false },
+                            new JsonAttribute("value", fact.Layout) { EscapeForwardSlash = false, Encode = !(fact.Layout is JsonLayout) },
+                        }
+                    });
+                }
+                facts.Layouts.Add(new SimpleLayout(" ]"));
+            }
+
+            var sections = new JsonLayout()
+            {
+                RenderEmptyObject = false,
+                Attributes = {
+                    new JsonAttribute("activityTitle", "${exception:format=type}"),
+                    new JsonAttribute("activitySubtitle", "${exception:format=message}"),
+                    new JsonAttribute("activityText", "${exception:format=tostring}"),
+                    new JsonAttribute("facts", facts) { Encode = false },
+                }
+            };
+            messageCardLayout.Attributes.Add(new JsonAttribute("sections", sections) { Encode = false });
+
+            _target.Layout = messageCardLayout;
+        }
+
+        public string CreateMessage(LogEventInfo logEvent, string applicationName, string environment)
+        {
+            return _target.RenderTargetLayout(logEvent);
+        }
+    }
+}


### PR DESCRIPTION
Allows you to add custom facts like this:

```xml
    <target xsi:type="MsTeams" name="fatalLog"
          Url="XXX PUT YOUR URL IN HERE XXX"
          ApplicationName="${var:appName}"
          Environment="Demonstration">
      <contextproperty name="Assigned To" layout="${environment-user:whenEmpty=Unassigned}" />
      <contextproperty name="Due Date" layout="${longdate}" />
      <contextproperty name="Status" layout="Not Started" />
    </target>
```

By using NLog JsonLayout to buid the Json-Document for the MessageCard:

![image](https://user-images.githubusercontent.com/11509660/149840445-8a13b676-af6d-4df2-ad93-77b5d97e3701.png)

See also: https://stackoverflow.com/questions/70736351/specify-dynamic-details-to-go-into-the-messagecard-using-nlog-targets-teams